### PR TITLE
add token login

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ local-gemma
 ```
 
 > [!TIP]
-> The first time you run the application, it will request a read token to download the model. You can follow [this guide](https://huggingface.co/docs/hub/en/security-tokens) to create a token, and pass it through the `--token` argument. If you're new to Hugging Face and never used a Gemma model, you'll also need to accept the terms at the top of [this page](https://huggingface.co/google/gemma-2-9b-it).
+> Local Gemma will check for a Hugging Face "read" token to download the model. You can follow [this guide](https://huggingface.co/docs/hub/en/security-tokens) to create a token, and pass it through the `--token` argument. If you're new to Hugging Face and never used a Gemma model, you'll also need to accept the terms at the top of [this page](https://huggingface.co/google/gemma-2-9b-it).
 
 Alternatively, you can request a single output by passing a prompt, such as:
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ local-gemma
 ```
 
 > [!TIP]
-> Local Gemma will check for a Hugging Face "read" token to download the model. You can follow [this guide](https://huggingface.co/docs/hub/en/security-tokens) to create a token, and pass it through the `--token` argument. If you're new to Hugging Face and never used a Gemma model, you'll also need to accept the terms at the top of [this page](https://huggingface.co/google/gemma-2-9b-it).
+> Local Gemma will check for a Hugging Face "read" token to download the model. You can follow [this guide](https://huggingface.co/docs/hub/en/security-tokens) to create a token, and pass it when prompted to log-in. If you're new to Hugging Face and never used a Gemma model, you'll also need to accept the terms at the top of [this page](https://huggingface.co/google/gemma-2-9b-it).
 
 Alternatively, you can request a single output by passing a prompt, such as:
 

--- a/local_gemma/cli.py
+++ b/local_gemma/cli.py
@@ -19,6 +19,7 @@ import torch
 from transformers import AutoTokenizer, TextStreamer, set_seed
 from transformers.utils import logging
 
+from huggingface_hub import get_token, login
 from local_gemma import LocalGemma2ForCausalLM
 from .utils.benchmark import benchmark
 from .utils.config import infer_device, infer_dtype, get_prompt, get_generation_kwargs, infer_memory_requirements
@@ -139,6 +140,13 @@ def main():
     generation_kwargs = get_generation_kwargs(args.mode)
     base_prompt = get_prompt(args.mode)
     model_name = MODEL_NAMES.get(args.model) or args.model
+    if args.token is None:
+        if get_token() is None:
+            print("Using the gated Gemma model requires you to:")
+            print("1. Create an account on the Hugging Face Hub: https://huggingface.co/join")
+            print("2. Accept the Gemma-2 model terms of use: https://huggingface.co/google/gemma-2-9b")
+            print("3. Create an access token and paste it below: https://huggingface.co/settings/tokens")
+            login()
 
     if args.preset == "auto":
         args.preset = infer_memory_requirements(model_name, device, trust_remote_code=False, token=args.token)


### PR DESCRIPTION
If the user doesn't pass the `--token` argument and we can't find a HF token in the cache, we prompt the user to login with a HF token through the CLI with step-by-step instructions:

<img width="1075" alt="Screenshot 2024-07-02 at 09 53 37" src="https://github.com/huggingface/local-gemma/assets/93869735/dac09c68-ed13-46f7-be38-45a287ef2b78">

