### PR TITLE
a10g with the `exact` preset by default on the 9b model

### DIFF
--- a/local_gemma/utils/config.py
+++ b/local_gemma/utils/config.py
@@ -98,7 +98,7 @@ def infer_memory_requirements(model_name, device=None, token=None, trust_remote_
 
     for preset in DTYPE_MODIFIER.keys():
         dtype_total_size = total_size / DTYPE_MODIFIER[preset]
-        inference_requirements = 1.2 * dtype_total_size
+        inference_requirements = 1.15 * dtype_total_size  # 1.15 allows A10G to run the `exact` preset on the 9b model
 
         if inference_requirements < total_memory:
             return preset


### PR DESCRIPTION
Fixes #20 

[A10G reports ~22GB by default](https://forums.developer.nvidia.com/t/gpu-memory-less-than-promised/232129). Our safety net of 20% memory resulted in A10G not loading the 9b model with the `exact` preset by default. Reducing it to 15% should enable the intended default in that common GPU 🤗 