### PR TITLE
Remove speed preset option from help text when unavailable

### DIFF
--- a/local_gemma/cli.py
+++ b/local_gemma/cli.py
@@ -47,7 +47,7 @@ parser.add_argument(
     type=str,
     default="9b",
     help=(
-        "Size of Gemma 2 instruct model to be used in the application ('9b' or '27'b) or, alternatively, a Hugging "
+        "Size of Gemma 2 instruct model to be used in the application ('9b' or '27b') or, alternatively, a Hugging "
         "Face repo. Defaults to '9b'."
     ),
 )
@@ -59,11 +59,11 @@ parser.add_argument(
 parser.add_argument(
     "--preset",
     type=str,
-    choices=["auto", "exact", "speed", "memory", "memory_extreme"],
+    choices=["auto", "exact", "memory", "memory_extreme"],
     default="auto",
     help=(
         "Sets the optimization strategy for the local model deployment. Defaults to 'auto', which selects the best "
-        "strategy for your device. 'exact' maximises accuracy, 'speed' maximises generation speed, 'memory' reduces "
+        "strategy for your device. 'exact' maximises accuracy, 'memory' reduces "
         "memory requirements through quantization, and 'memory_extreme' minimises memory requirements."
     ),
 )


### PR DESCRIPTION
The `speed` preset option has been removed from the command help text to prevent confusion and errors. Currently, selecting a `speed` preset that is not available results in a `ValueError: Got invalid 'preset' speed. Ensure 'preset' is one of: ['auto', 'exact', 'memory', 'memory_extreme']`. This change ensures that only valid options are presented in the help text.