### PR TITLE
Add hqq quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ to improve the inference speed, stay tuned! Any contributions in Transformers ar
 Local Gemma-2 is a convenient wrapper around several open-source projects, which we thank explicitly below:
 * [Transformers](https://huggingface.co/docs/transformers/en/index) for the PyTorch Gemma-2 implementation. Particularly [Arthur Zucker](https://github.com/ArthurZucker) for adding the model and the logit soft-capping fixes.
 * [bitsandbytes](https://huggingface.co/docs/bitsandbytes/index) for the 4-bit optimization on CUDA.
+* [hqq](https://github.com/mobiusml/hqq) for the 4-bit optimization and faster inference on CUDA.
 * [quanto](https://github.com/huggingface/optimum-quanto) for the 4-bit optimization on MPS + CPU.
 * [Accelerate](https://huggingface.co/docs/accelerate/en/index) for the large model loading utilities.
 

--- a/local_gemma/cli.py
+++ b/local_gemma/cli.py
@@ -91,6 +91,13 @@ parser.add_argument(
     help="Forces a specific device to be used. By default uses cuda > mps > cpu, depending on availability.",
 )
 parser.add_argument(
+    "--quantization",
+    type=str,
+    choices=["bnb", "hqq"],
+    default="bnb",
+    help="Set the quantization method to use when using a cuda device",
+)
+parser.add_argument(
     "--dtype",
     type=str,
     help="The dtype in which computations are performed. Defaults to the dtype set by --preset",
@@ -106,6 +113,7 @@ parser.add_argument(
     type=int,
     help="Seed for text generation. Optional, use for reproducibility.",
 )
+
 parser.add_argument(
     "--benchmark",
     action="store_true",

--- a/local_gemma/cli.py
+++ b/local_gemma/cli.py
@@ -184,7 +184,7 @@ def main():
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, token=args.token)
     model = LocalGemma2ForCausalLM.from_pretrained(
-        model_name, preset=args.preset, token=args.token, torch_dtype=dtype, device=device
+        model_name, preset=args.preset, token=args.token, torch_dtype=dtype, device=device, quantization = args.quantization
     )
     # TODO(joao): this if shouldn't be needed, fix in transformers
     model._supports_cache_class = True

--- a/local_gemma/modeling_local_gemma_2.py
+++ b/local_gemma/modeling_local_gemma_2.py
@@ -173,5 +173,9 @@ class LocalGemma2ForCausalLM(Gemma2ForCausalLM):
         if device not in str(model.device) and preset_kwargs.get("device_map", None) is None:
             # for consistent behaviour with bitsandbytes, we move the model to the device always
             model.to(device, dtype=preset_kwargs["torch_dtype"])
+    
+        if device == "cuda" and quantization == "hqq":
+            from hqq.utils.patching import prepare_for_inference
+            prepare_for_inference(model, backend="torchao_int4")
 
         return model

--- a/local_gemma/modeling_local_gemma_2.py
+++ b/local_gemma/modeling_local_gemma_2.py
@@ -174,7 +174,7 @@ class LocalGemma2ForCausalLM(Gemma2ForCausalLM):
             # for consistent behaviour with bitsandbytes, we move the model to the device always
             model.to(device, dtype=preset_kwargs["torch_dtype"])
     
-        if device == "cuda" and quantization == "hqq":
+        if quantization_config is not None and device == "cuda" and quantization == "hqq":
             from hqq.utils.patching import prepare_for_inference
             prepare_for_inference(model, backend="torchao_int4")
 

--- a/local_gemma/modeling_local_gemma_2.py
+++ b/local_gemma/modeling_local_gemma_2.py
@@ -109,6 +109,7 @@ class LocalGemma2ForCausalLM(Gemma2ForCausalLM):
         **kwargs,
     ) -> Gemma2ForCausalLM:
         device = infer_device(kwargs.pop("device", None))
+        quantization = kwargs.pop("quantization", None)
         preset_kwargs = cls.get_preset_kwargs(
             pretrained_model_name_or_path,
             preset,
@@ -134,7 +135,6 @@ class LocalGemma2ForCausalLM(Gemma2ForCausalLM):
             preset_kwargs["quantization_config"] = quantization_config
         elif preset_kwargs.get("quantization_config"):
             if device == "cuda":
-                quantization = preset_kwargs["quantization"]
                 if quantization == "hqq":
                     preset_kwargs["quantization_config"] = HqqConfig(nbits=4, group_size=64, quant_zero=False, quant_scale=False, axis=1) 
                     preset_kwargs["device_map"] = "cuda"


### PR DESCRIPTION
# What does this PR do ? 
This PR adds the possibility to quantize the model with hqq instead of bnb when using a `cuda` device. 
HQQ is faster than BNB but takes a bit of time of quantize (4min hqq vs 30s bnb)

Run the following: 
`local-gemma --model 27b --preset memory --mode factual --quantization hqq`

cc @mobiusml @gante @Vaibhavs10 