### PR TITLE
Remove MPS Fallback Environ variable.

### DIFF
--- a/local_gemma/modeling_local_gemma_2.py
+++ b/local_gemma/modeling_local_gemma_2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
 from typing import Optional, Union, Dict
 import logging


### PR DESCRIPTION
From transformers 4.30 onward, we have regained the capability to run directly on `mps` without fallback!